### PR TITLE
Fix building on wayland backend

### DIFF
--- a/druid-shell/src/backend/wayland/window.rs
+++ b/druid-shell/src/backend/wayland/window.rs
@@ -394,10 +394,18 @@ impl WindowBuilder {
         );
     }
 
+    pub fn show_title(&mut self, _show_title: bool) {
+        // Ignored
+    }
+
     pub fn set_transparent(&mut self, _transparent: bool) {
         tracing::warn!(
             "set_transparent unimplemented for wayland, it allows transparency by default"
         );
+    }
+
+    pub fn set_transparent_titlebar(&mut self, _transparent_titlebar: bool) {
+        // Ignored
     }
 
     pub fn set_position(&mut self, position: Point) {


### PR DESCRIPTION
Fix building on wayland backend by adding stubs for `show_title` and `set_transparent_titlebar`.

The stubs on all platforms should probably also have `tracing::warn!`s saying they're unimplemented/irrelevant but that's unrelated to this PR.